### PR TITLE
Enhancements for the pytest-prometheus plugin

### DIFF
--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -43,9 +43,9 @@ class PrometheusReport:
         self.job_name = config.getoption('prometheus_job_name')
         self.registry = CollectorRegistry()
 
-        self.passed = 0
-        self.failed = 0
-        self.skipped = 0
+        self.passed = []
+        self.failed = []
+        self.skipped = []
 
         self.extra_labels = {item[0]: item[1] for item in [i.split('=', 1) for i in config.getoption('prometheus_extra_label')]}
 
@@ -60,52 +60,57 @@ class PrometheusReport:
         replacement = '_'
         return re.sub(pattern, replacement, unsanitized_name)
 
+    def _make_labels(self, testname):
+        ret = self.extra_labels.copy()
+        ret["testname"] = testname
+        return ret
+
+    def _get_label_names(self):
+        return self._make_labels("").keys()
+
+    def add_metrics_for_tests(self, metric, testnames):
+        for testname in testnames:
+            labels = self._make_labels(testname)
+            metric.labels(**labels).inc()
+
+
     def pytest_runtest_logreport(self, report):
         # https://docs.pytest.org/en/latest/reference.html#_pytest.runner.TestReport.when
         # 'call' is the phase when the test is being ran
         if report.when == 'call':
 
-            metric_value = 0
-
-            if report.outcome == 'passed':
-                self.passed += 1
-                metric_value = 1
-            elif report.outcome == 'skipped':
-                self.skipped += 1
-            elif report.outcome == 'failed':
-                self.failed += 1
-
-
             funcname = report.location[2]
             name = self._make_metric_name(funcname)
-            logging.debug("Creating metric {name}".format(name=name))
-            metric = Gauge(name,
-                    report.nodeid,
-                    labelnames=self.extra_labels.keys(),
-                    registry=self.registry)
-            # You can't just call metric.set(), you have to call metric.labels() first and include
-            # all the labels declared as `labelnames` in the constructor
-            metric.labels(**self.extra_labels).set(metric_value)
+
+            if report.outcome == 'passed':
+                self.passed.append(name)
+            elif report.outcome == 'skipped':
+                self.skipped.append(name)
+            elif report.outcome == 'failed':
+                self.failed.append(name)
+
+
 
     def pytest_sessionfinish(self, session):
 
         passed_metric = Gauge(self._make_metric_name("passed"),
                 "Number of passed tests",
-                labelnames=self.extra_labels.keys(),
+                labelnames=self._get_label_names(),
                 registry=self.registry)
-        passed_metric.labels(**self.extra_labels).set(self.passed)
+        self.add_metrics_for_tests(passed_metric, self.passed)
+
 
         failed_metric = Gauge(self._make_metric_name("failed"),
                 "Number of failed tests",
-                labelnames=self.extra_labels.keys(),
+                labelnames=self._get_label_names(),
                 registry=self.registry)
-        failed_metric.labels(**self.extra_labels).set(self.failed)
+        self.add_metrics_for_tests(failed_metric, self.failed)
 
         skipped_metric = Gauge(self._make_metric_name("skipped"),
                 "Number of skipped tests",
-                labelnames=self.extra_labels.keys(),
+                labelnames=self._get_label_names(),
                 registry=self.registry)
-        skipped_metric.labels(**self.extra_labels).set(self.skipped)
+        self.add_metrics_for_tests(skipped_metric, self.skipped)
 
         push_to_gateway(self.pushgateway_url, registry=self.registry, job=self.job_name)
 

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -84,21 +84,21 @@ class PrometheusReport:
 
         passed_metric = Gauge(self._make_metric_name("passed"),
                 "Number of passed tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        passed_metric.set(self.passed)
+        passed_metric.labels(**self.extra_labels).set(self.passed)
 
         failed_metric = Gauge(self._make_metric_name("failed"),
                 "Number of failed tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        failed_metric.set(self.failed)
+        failed_metric.labels(**self.extra_labels).set(self.failed)
 
         skipped_metric = Gauge(self._make_metric_name("skipped"),
                 "Number of skipped tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        skipped_metric.set(self.skipped)
+        skipped_metric.labels(**self.extra_labels).set(self.skipped)
 
         push_to_gateway(self.pushgateway_url, registry=self.registry, job=self.job_name)
 

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -1,5 +1,5 @@
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway, generate_latest
 import logging
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 
 def pytest_addoption(parser):
     group = parser.getgroup('terminal reporting')

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -1,4 +1,4 @@
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway, generate_latest
+from prometheus_client import CollectorRegistry, Gauge, pushadd_to_gateway, generate_latest
 
 def pytest_addoption(parser):
     group = parser.getgroup('terminal reporting')
@@ -53,4 +53,4 @@ class PrometheusReport:
             print("Pushing metric {name}".format(name=name))
             metric = Gauge(name, report.nodeid, self.extra_labels.keys(), registry=registry)
             metric.labels(**self.extra_labels).set(1 if report.outcome == 'passed' else 0)
-            push_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)
+            pushadd_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -50,6 +50,7 @@ class PrometheusReport:
                 prefix=self.prefix,
                 funcname=report.location[2]
             )
+            print("Pushing metric {name}".format(name=name))
             metric = Gauge(name, report.nodeid, self.extra_labels.keys(), registry=registry)
             metric.labels(**self.extra_labels).set(1 if report.outcome == 'passed' else 0)
             push_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-prometheus',
-    version='0.2',
+    version='0.3',
     description='Report test pass / failures to a Prometheus PushGateway',
     author='Yuvi Panda',
     author_email='yuvipanda@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-prometheus',
-    version='0.3',
+    version='0.4',
     description='Report test pass / failures to a Prometheus PushGateway',
     author='Yuvi Panda',
     author_email='yuvipanda@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-prometheus',
-    version='0.1',
+    version='0.2',
     description='Report test pass / failures to a Prometheus PushGateway',
     author='Yuvi Panda',
     author_email='yuvipanda@gmail.com',


### PR DESCRIPTION
Hello! Not sure if this project is abandoned but I made some improvements based on my use-case that I wanted to merge back upstream.

Main changes:
1) Only push to pushgateway at the end of the pytest session (instead of after every test) - this also fixes an issue I noticed where only the final test would show up in the pushgateway results because this library was calling `push_to_pushgateway` instead of `pushadd_to_pushgateway`. The difference between the two functions mostly goes away when pushing them all at the end, instead of incrementally
2) Include metrics for number of failed, skipped, and passed tests